### PR TITLE
start script should match app name

### DIFF
--- a/src/main/g8/package/after-install.sh
+++ b/src/main/g8/package/after-install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/etc/init.d/rpm-builder start
+/etc/init.d/$name;format="norm"$ start


### PR DESCRIPTION
Fix bug, hardcoded app name should use name variable.
